### PR TITLE
:wrench: #6 Mapstruct Unmapped Target Warning 제거 _ Member 도메인에 실수로 제거

### DIFF
--- a/src/main/java/com/seollem/server/member/MemberMapper.java
+++ b/src/main/java/com/seollem/server/member/MemberMapper.java
@@ -1,8 +1,9 @@
 package com.seollem.server.member;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface MemberMapper {
 
   Member memberPostToMember(MemberDto.Post requestBody);


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #6 

## 🙌 구현 사항
- PR #7 참조

## 📝 구현 설명
- 실수로 Member Mapper 의 unmappedTargetPolicy 설정 제거한 것 수정하였습니다.
