### PR TITLE
:bug: #28 임시비밀번호 생성 로직 변경

### DIFF
--- a/src/main/java/com/seollem/server/temppassword/TempPasswordService.java
+++ b/src/main/java/com/seollem/server/temppassword/TempPasswordService.java
@@ -1,6 +1,5 @@
 package com.seollem.server.temppassword;
 
-import java.util.UUID;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -36,9 +35,28 @@ public class TempPasswordService {
   }
 
   public String createTempPassword() {
-    String tempPassword = UUID.randomUUID().toString().replace("-", ""); // '-'를 제거
-    tempPassword = tempPassword.substring(0, 10); //임시 비밀번호는 10자리 문자열
-    return tempPassword;
+    StringBuilder result = new StringBuilder();
+
+    char[] pwCollectionSpCha = new char[] {'!', '@', '#', '$', '%', '^', '&', '*', '(', ')'};
+    char[] pwCollectionNum = new char[] {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0',};
+    char[] pwCollectionEng = new char[] {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+        'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
+    return getRandPw(4, pwCollectionEng) + getRandPw(1,
+        pwCollectionSpCha) + getRandPw(4, pwCollectionNum) + getRandPw(2,
+        pwCollectionSpCha);
+  }
+
+  public String getRandPw(int size, char[] pwCollection) {
+    String ranPw = "";
+
+    for (int i = 0; i < size; i++) {
+      int selectRandomPw = (int) (Math.random() * (pwCollection.length));
+      ranPw += pwCollection[selectRandomPw];
+    }
+    return ranPw;
   }
 
 }


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #28 

## 🙌 구현 사항
- 임시비밀번호 생성 로직을 변경하였습니다.

## 📝 구현 설명
- 기존의 임시비밀번호 생성로직은 팀에서 설정한 비밀번호 유효성 검증을 고려하지 않고 구현되었습니다. 따라서 팀에서 설정한 유효성을 만족하는 임시비밀번호를 생성하도록 변경하였습니다.

#### 기존 코드
- `createTempPassword()`
```java
public String createTempPassword() {
    String tempPassword = UUID.randomUUID().toString().replace("-", ""); // '-'를 제거
    tempPassword = tempPassword.substring(0, 10); //임시 비밀번호는 10자리 문자열
    return tempPassword;
  }
  ```
 `UUID.randomUUID()` 를 이용하여 type4 UUID 문자열을 생성하는 방법을 사용했으나, 이는 **영문 대소문자, 숫자, 특수문자를 포함한 6자리 이상** 이라는 비밀번호 유효성을 고려하지 않은 로직이었습니다.
 
#### 변경된 코드
- `createTempPassword()`
```java
public String createTempPassword() {
    StringBuilder result = new StringBuilder();

    char[] pwCollectionSpCha = new char[] {'!', '@', '#', '$', '%', '^', '&', '*', '(', ')'};
    char[] pwCollectionNum = new char[] {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0',};
    char[] pwCollectionEng = new char[] {
        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
        'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
        's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
    return getRandPw(4, pwCollectionEng) + getRandPw(1,
        pwCollectionSpCha) + getRandPw(4, pwCollectionNum) + getRandPw(2,
        pwCollectionSpCha);
  }
```
- `getRandPw()`
```java
public String getRandPw(int size, char[] pwCollection) {
    String ranPw = "";

    for (int i = 0; i < size; i++) {
      int selectRandomPw = (int) (Math.random() * (pwCollection.length));
      ranPw += pwCollection[selectRandomPw];
    }
    return ranPw;
  }
```
영문 대소문자, 숫자, 특수문자로 이루어진 문자 배열을 선언해두고, `Math.random()` 을 통해 랜덤으로 선택하도록 구현했습니다. 
그리고 4자리의 영문자, 1자리의 특수문자, 4자리의 숫자, 2자리의 특수문자로 임시비밀번호를 생성했습니다.

여기서 고정된 자리에 고정된 종류의 문자를 지정하는 것에 대해 논리적, 보안적인 고민을 해보았습니다만, 반드시 랜덤한 자리에 어떠한 종류의 문자가 들어갈 필요는 없다고 판단했고 보안적으로도 암호화가 이뤄지며 비밀번호를 유추할 확률도 매우 낮으므로 괜찮다고 판단했습니다. (4자리의 영문자 : 1/28^4, 1자리의 특수문자 : 1/10, 4자리의 숫자 : 1/10, 2자리의 특수문자 : 1/10^2)