### PR TITLE
:recycle: #39 Spring Rest Docs 테스트 코드 중 Book 도메인 리팩토링 : TestSetUpForB…

### DIFF
--- a/src/test/java/com/seollem/server/restdocs/controller/book/DeleteBook.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/DeleteBook.java
@@ -14,42 +14,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.seollem.server.book.Book;
 import com.seollem.server.book.BookController;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(value = BookController.class)
-public class DeleteBook extends WebMvcTestSetUpUtil {
-
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
-
+public class DeleteBook extends TestSetUpForBookUtil {
 
   @Test
   public void deleteBookTest() throws Exception {

--- a/src/test/java/com/seollem/server/restdocs/controller/book/GetBooksHaveMemo.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/GetBooksHaveMemo.java
@@ -12,23 +12,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.google.gson.Gson;
 import com.seollem.server.book.BookController;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
 import com.seollem.server.member.Member;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -39,22 +31,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(BookController.class)
-public class GetBooksHaveMemo extends WebMvcTestSetUpUtil {
-
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
+public class GetBooksHaveMemo extends TestSetUpForBookUtil {
 
   @Autowired
   private Gson gson;

--- a/src/test/java/com/seollem/server/restdocs/controller/book/GetCalender.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/GetCalender.java
@@ -13,23 +13,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.google.gson.Gson;
 import com.seollem.server.book.Book.BookStatus;
 import com.seollem.server.book.BookController;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
 import com.seollem.server.member.Member;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -40,22 +32,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(BookController.class)
-public class GetCalender extends WebMvcTestSetUpUtil {
-
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
+public class GetCalender extends TestSetUpForBookUtil {
 
   @Autowired
   private Gson gson;

--- a/src/test/java/com/seollem/server/restdocs/controller/book/GetDetail.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/GetDetail.java
@@ -15,21 +15,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.google.gson.Gson;
 import com.seollem.server.book.BookController;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -40,22 +32,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(BookController.class)
-public class GetDetail extends WebMvcTestSetUpUtil {
-
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
+public class GetDetail extends TestSetUpForBookUtil {
 
   @Autowired
   private Gson gson;

--- a/src/test/java/com/seollem/server/restdocs/controller/book/GetLibrary.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/GetLibrary.java
@@ -13,23 +13,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.google.gson.Gson;
 import com.seollem.server.book.Book.BookStatus;
 import com.seollem.server.book.BookController;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
 import com.seollem.server.member.Member;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -43,22 +35,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
  */
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(BookController.class)
-public class GetLibrary extends WebMvcTestSetUpUtil {
+public class GetLibrary extends TestSetUpForBookUtil {
 
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
 
   @Autowired
   private Gson gson;

--- a/src/test/java/com/seollem/server/restdocs/controller/book/GetMemos.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/GetMemos.java
@@ -15,21 +15,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.google.gson.Gson;
 import com.seollem.server.book.BookController;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -40,22 +32,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(BookController.class)
-public class GetMemos extends WebMvcTestSetUpUtil {
-
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
+public class GetMemos extends TestSetUpForBookUtil {
 
   @Autowired
   private Gson gson;

--- a/src/test/java/com/seollem/server/restdocs/controller/book/PatchBook.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/PatchBook.java
@@ -20,23 +20,15 @@ import com.seollem.server.book.Book.BookStatus;
 import com.seollem.server.book.BookController;
 import com.seollem.server.book.BookDto;
 import com.seollem.server.book.BookDto.Patch;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.GsonCustomConfig;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import java.nio.charset.Charset;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -44,23 +36,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(BookController.class)
-public class PatchBook extends WebMvcTestSetUpUtil {
+public class PatchBook extends TestSetUpForBookUtil {
 
   private final GsonCustomConfig gsonCustomConfig = new GsonCustomConfig();
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
 
   @Test
   public void patchBookTest() throws Exception {

--- a/src/test/java/com/seollem/server/restdocs/controller/book/PostBook.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/PostBook.java
@@ -17,45 +17,22 @@ import com.seollem.server.book.Book;
 import com.seollem.server.book.Book.BookStatus;
 import com.seollem.server.book.BookController;
 import com.seollem.server.book.BookDto;
-import com.seollem.server.book.BookMapper;
-import com.seollem.server.book.BookService;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
 import com.seollem.server.restdocs.util.GsonCustomConfig;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForBookUtil;
 import java.nio.charset.Charset;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(value = BookController.class)
-public class PostBook extends WebMvcTestSetUpUtil {
-
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private BookMapper bookMapper;
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemoLikesService memoLikesService;
+public class PostBook extends TestSetUpForBookUtil {
 
   private final GsonCustomConfig gsonCustomConfig = new GsonCustomConfig();
 

--- a/src/test/java/com/seollem/server/restdocs/util/TestSetUpForBookUtil.java
+++ b/src/test/java/com/seollem/server/restdocs/util/TestSetUpForBookUtil.java
@@ -1,0 +1,32 @@
+package com.seollem.server.restdocs.util;
+
+import com.seollem.server.book.BookMapper;
+import com.seollem.server.book.BookService;
+import com.seollem.server.member.MemberService;
+import com.seollem.server.memo.MemoMapper;
+import com.seollem.server.memo.MemoService;
+import com.seollem.server.memolikes.MemoLikesService;
+import com.seollem.server.util.GetAbandonPeriodUtil;
+import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class TestSetUpForBookUtil extends WebMvcTestSetUpUtil {
+
+  @MockBean
+  protected GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
+  @MockBean
+  protected MemberService memberService;
+  @MockBean
+  protected BookService bookService;
+  @MockBean
+  protected BookMapper bookMapper;
+  @MockBean
+  protected MemoService memoService;
+  @MockBean
+  protected MemoMapper memoMapper;
+  @MockBean
+  protected MemoLikesService memoLikesService;
+  @MockBean
+  protected GetAbandonPeriodUtil getAbandonPeriodUtil;
+
+}


### PR DESCRIPTION
…ookUtil 클래스 구현 및 사용

## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #39 

## 🙌 구현 사항

## 📝 구현 설명

- Spring Rest Docs 테스트 코드에서 Book 도메인의 중복되는 @MockBean 코드들을 상속으로 처리하도록 하였습니다.
- 기존의 WebMvcTestSetUpUtil 클래스를 상속하고 @MockBean 코드들을 가지는 WebMvcTestSetUpUtil 클래스를 구현하였습니다.
```java
public class TestSetUpForBookUtil extends WebMvcTestSetUpUtil {

  @MockBean
  protected GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
  @MockBean
  protected MemberService memberService;
  @MockBean
  protected BookService bookService;
  @MockBean
  protected BookMapper bookMapper;
  @MockBean
  protected MemoService memoService;
  @MockBean
  protected MemoMapper memoMapper;
  @MockBean
  protected MemoLikesService memoLikesService;
  @MockBean
  protected GetAbandonPeriodUtil getAbandonPeriodUtil;

}
```
- 위 클래스를 Book 도메인 클래스들이 모두 상속받도록 변경하였습니다.