### PR TITLE
Feature/#31 member domain change

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -228,6 +228,22 @@ include::{snippets}/PatchMember/http-response.adoc[]
 .response fields
 include::{snippets}/PatchMember/response-fields.adoc[]
 
+=== 회원 이미지 등록
+.request
+include::{snippets}/PostMemberImage/http-request.adoc[]
+
+.request headers
+include::{snippets}/PostMemberImage/request-headers.adoc[]
+
+.request parts
+include::{snippets}/PostMemberImage/request-parts.adoc[]
+
+.response
+include::{snippets}/PostMemberImage/http-response.adoc[]
+
+.response fields
+include::{snippets}/PostMemberImage/response-fields.adoc[]
+
 === 회원 삭제
 .request
 include::{snippets}/DeleteMember/http-request.adoc[]

--- a/src/main/java/com/seollem/server/exception/ExceptionCode.java
+++ b/src/main/java/com/seollem/server/exception/ExceptionCode.java
@@ -3,19 +3,18 @@ package com.seollem.server.exception;
 import lombok.Getter;
 
 public enum ExceptionCode {
-  MEMBER_NOT_FOUND(404, "Member not found"),
-  MEMBER_EXISTS(400, "Member already exists"),
+  MEMBER_NOT_FOUND(404, "Member not found"), MEMBER_EXISTS(400, "Member already exists"),
   MEMBER_AUTHENTICATIONCODE_INVALID(404, "Member authentication code invalid "),
-  BOOK_NOT_FOUND(404, "Book not found"),
-  BOOK_EXISTS(400, "Book already exists"),
+  BOOK_NOT_FOUND(404, "Book not found"), BOOK_EXISTS(400, "Book already exists"),
 
   BOOK_NOT_FOUND_PERIOD(404, "Books not found in period"),
 
   BOOK_STATUS_WRONG(400, "Wrong value in bookStatus and readDate"),
-  NOT_MEMBER_BOOK(400, "Not member's book"),
-  MEMO_NOT_FOUND(404, "Memo not found"),
+  NOT_MEMBER_BOOK(400, "Not member's book"), MEMO_NOT_FOUND(404, "Memo not found"),
 
-  NOT_MEMBER_MEMO(400, "Not member's memo");
+  NOT_MEMBER_MEMO(400, "Not member's memo"),
+
+  IMAGE_UPLOAD_FAIL(500, "Image upload failed.");
 
   @Getter
   private final int status;

--- a/src/main/java/com/seollem/server/file/FileUploadService.java
+++ b/src/main/java/com/seollem/server/file/FileUploadService.java
@@ -1,15 +1,19 @@
 package com.seollem.server.file;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.seollem.server.exception.BusinessLogicException;
+import com.seollem.server.exception.ExceptionCode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @AllArgsConstructor
+@Slf4j
 public class FileUploadService {
 
   private final AmazonS3Service s3Service;
@@ -22,8 +26,8 @@ public class FileUploadService {
     try (InputStream inputStream = file.getInputStream()) {
       s3Service.uploadFile(inputStream, objectMetadata, fileName);
     } catch (IOException e) {
-      throw new IllegalArgumentException(
-          String.format("파일 변환 중 에러 발생 (%s)", file.getOriginalFilename()));
+      log.error(String.format("파일 변환 중 에러 발생 (%s)", file.getOriginalFilename()));
+      throw new BusinessLogicException(ExceptionCode.IMAGE_UPLOAD_FAIL);
     }
     return s3Service.getFileUrl(fileName);
   }

--- a/src/main/java/com/seollem/server/jjwt/service/PrincipalDetailsService.java
+++ b/src/main/java/com/seollem/server/jjwt/service/PrincipalDetailsService.java
@@ -37,6 +37,8 @@ public class PrincipalDetailsService implements UserDetailsService {
       setEmail(member.getEmail());
       setPassword(member.getPassword());
       setRoles(member.getRoles());
+      setContent(member.getContent());
+      setUrl(member.getUrl());
     }
 
 

--- a/src/main/java/com/seollem/server/member/Member.java
+++ b/src/main/java/com/seollem/server/member/Member.java
@@ -37,10 +37,8 @@ public class Member extends Auditable {
   @Column(nullable = false)
   private String password;
   private String roles;
-
- private String profile;
-
- private String url;
+  private String content;
+  private String url;
 
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
   private List<Book> books = new ArrayList<>();

--- a/src/main/java/com/seollem/server/member/MemberController.java
+++ b/src/main/java/com/seollem/server/member/MemberController.java
@@ -1,7 +1,6 @@
 package com.seollem.server.member;
 
 import com.seollem.server.file.FileUploadService;
-import com.seollem.server.memo.MemoDto;
 import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
 import java.util.Map;
 import javax.validation.Valid;
@@ -27,13 +26,13 @@ public class MemberController {
   private final MemberMapper memberMapper;
   private final MemberService memberService;
   private final GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-
   private final FileUploadService fileUploadService;
 
   public MemberController(
       MemberMapper memberMapper,
       MemberService memberService,
-      GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil, FileUploadService fileUploadService) {
+      GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil,
+      FileUploadService fileUploadService) {
     this.memberMapper = memberMapper;
     this.memberService = memberService;
     this.getEmailFromHeaderTokenUtil = getEmailFromHeaderTokenUtil;
@@ -41,15 +40,14 @@ public class MemberController {
   }
 
 
-  @PostMapping("/image-member")
-  public ResponseEntity postImageMemo(@RequestHeader Map<String, Object> requestHeader,
-                                      @RequestPart MultipartFile file) {
+  @PostMapping("/member-image")
+  public ResponseEntity postMemberImage(@RequestHeader Map<String, Object> requestHeader,
+      @RequestPart MultipartFile file) {
     String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
     Member member = memberService.findVerifiedMemberByEmail(email);
 
     String url = fileUploadService.createImage(file);
-    member.setUrl(url);
-    memberService.updateMember(member);
+    memberService.updateMemberImage(member, url);
 
     MemberDto.ImageMemberResponse imageMemberResponse = new MemberDto.ImageMemberResponse(url);
 
@@ -61,7 +59,6 @@ public class MemberController {
   public ResponseEntity getMember(@RequestHeader Map<String, Object> requestHeader) {
     String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
     Member member = memberService.findVerifiedMemberByEmail(email);
-
 
     return new ResponseEntity<>(memberMapper.memberToMemberGetResponse(member), HttpStatus.OK);
   }

--- a/src/main/java/com/seollem/server/member/MemberDto.java
+++ b/src/main/java/com/seollem/server/member/MemberDto.java
@@ -61,7 +61,7 @@ public class MemberDto {
 
     private String email;
     private String name;
-    private String profile;
+    private String content;
     private String url;
   }
 

--- a/src/main/java/com/seollem/server/member/MemberDto.java
+++ b/src/main/java/com/seollem/server/member/MemberDto.java
@@ -48,7 +48,7 @@ public class MemberDto {
         message = "비밀번호는 알파벳, 숫자, 특수문자 포함 6자 이상이어야 합니다.")
     private String password;
 
-    private String profile;
+    private String content;
 
     private String url;
   }
@@ -74,7 +74,7 @@ public class MemberDto {
     private String email;
     private String name;
     private LocalDateTime updatedAt;
-    private String profile;
+    private String content;
     private String url;
   }
 

--- a/src/main/java/com/seollem/server/member/MemberService.java
+++ b/src/main/java/com/seollem/server/member/MemberService.java
@@ -31,9 +31,15 @@ public class MemberService {
     Optional.ofNullable(member.getName()).ifPresent(name -> findMember.setName(name));
     Optional.ofNullable(member.getPassword())
         .ifPresent(password -> findMember.setPassword(bCryptPasswordEncoder.encode(password)));
-    Optional.ofNullable(member.getUrl()).ifPresent(url ->findMember.setUrl(url));
+    Optional.ofNullable(member.getUrl()).ifPresent(url -> findMember.setUrl(url));
+    Optional.ofNullable(member.getContent()).ifPresent(content -> findMember.setContent(content));
 
     return memberRepository.save(findMember);
+  }
+
+  public Member updateMemberImage(Member member, String url) {
+    member.setUrl(url);
+    return memberRepository.save(member);
   }
 
   public void deleteMember(String email) {

--- a/src/main/java/com/seollem/server/memo/MemoController.java
+++ b/src/main/java/com/seollem/server/memo/MemoController.java
@@ -69,9 +69,9 @@ public class MemoController {
     String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
     Member member = memberService.findVerifiedMemberByEmail(email);
 
-    String url = fileUploadService.createImageMemo(file);
+    String url = fileUploadService.createImage(file);
 
-    MemoDto.ImageMemoResponse imageMemoResponse = new ImageMemoResponse(url);
+    ImageMemoResponse imageMemoResponse = new ImageMemoResponse(url);
 
     return new ResponseEntity<>(imageMemoResponse, HttpStatus.CREATED);
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,10 +10,14 @@ logging.level.org.hibernate.orm.jdbc.bind=trace
 logging.level.com.amazonaws.util.EC2MetadataUtils=error
 server.servlet.encoding.force-response=true
 logging.level.root=info
+#Pretty logging
+spring.output.ansi.enabled=always
+#AWS S3
 cloud.aws.credentials.profile-name=stratospheric
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.s3.bucket=be-35-bucket
 cloud.aws.stack.auto=false
+#Secrets Key File
 spring.profiles.include=SECRETS
 #Redis
 spring.redis.host=127.0.0.1

--- a/src/test/java/com/seollem/server/restdocs/controller/book/PatchBook.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/PatchBook.java
@@ -50,7 +50,8 @@ public class PatchBook extends TestSetUpForBookUtil {
     when(memberService.findVerifiedMemberByEmail(Mockito.anyString())).thenReturn(
         StubDataUtil.MockMember.getMember());
 
-    when(bookService.verifyBookStatus(Mockito.any())).thenReturn(StubDataUtil.MockBook.getBook());
+    when(bookService.verifyPatchBookStatus(Mockito.any())).thenReturn(
+        StubDataUtil.MockBook.getBook());
 
     doNothing().when(bookService).verifyMemberHasBook(Mockito.anyLong(), Mockito.anyLong());
 

--- a/src/test/java/com/seollem/server/restdocs/controller/member/DeleteMember.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/DeleteMember.java
@@ -10,28 +10,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.seollem.server.member.MemberController;
-import com.seollem.server.member.MemberMapper;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForMemberUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(value = MemberController.class)
-public class DeleteMember extends WebMvcTestSetUpUtil {
-
-  @MockBean
-  private MemberMapper memberMapper;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
+public class DeleteMember extends TestSetUpForMemberUtil {
 
 
   @Test

--- a/src/test/java/com/seollem/server/restdocs/controller/member/GetMember.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/GetMember.java
@@ -10,16 +10,12 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.seollem.server.member.MemberController;
-import com.seollem.server.member.MemberMapper;
-import com.seollem.server.member.MemberService;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForMemberUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -30,14 +26,8 @@ import org.springframework.test.web.servlet.ResultActions;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(MemberController.class)
-public class GetMember extends WebMvcTestSetUpUtil {
+public class GetMember extends TestSetUpForMemberUtil {
 
-  @MockBean
-  private MemberMapper memberMapper;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
 
   @Test
   public void getMemberTest() throws Exception {
@@ -62,8 +52,6 @@ public class GetMember extends WebMvcTestSetUpUtil {
             fieldWithPath("url").type(JsonFieldType.STRING).description("이미지"),
             fieldWithPath("profile").type(JsonFieldType.STRING).description("프로필")
 
-
-
-            )));
+        )));
   }
 }

--- a/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
@@ -16,18 +16,14 @@ import com.seollem.server.member.Member;
 import com.seollem.server.member.MemberController;
 import com.seollem.server.member.MemberDto;
 import com.seollem.server.member.MemberDto.Patch;
-import com.seollem.server.member.MemberMapper;
-import com.seollem.server.member.MemberService;
 import com.seollem.server.restdocs.util.GsonCustomConfig;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForMemberUtil;
 import java.nio.charset.Charset;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -35,15 +31,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 @WebMvcTest(MemberController.class)
-public class PatchMember extends WebMvcTestSetUpUtil {
+public class PatchMember extends TestSetUpForMemberUtil {
 
   private final GsonCustomConfig gsonCustomConfig = new GsonCustomConfig();
-  @MockBean
-  private MemberMapper memberMapper;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
 
   @Test
   public void patchMemberTest() throws Exception {
@@ -64,7 +54,8 @@ public class PatchMember extends WebMvcTestSetUpUtil {
     when(memberMapper.memberToMemberPatchResponse(Mockito.any())).thenReturn(
         StubDataUtil.MockMember.getMemberPatchResponse());
 
-    MemberDto.Patch patch = new Patch("이슬", "modi!@#pas1");
+    MemberDto.Patch patch =
+        new Patch("이슬", "modi!@#pas1", "안녕하세요. 김형섭입니다.", "https://profileImage.com");
     String content = gson.toJson(patch);
 
     //when, then
@@ -81,16 +72,16 @@ public class PatchMember extends WebMvcTestSetUpUtil {
             requestFields(
                 fieldWithPath("name").description("변경할 이름"),
                 fieldWithPath("password").description("변경할 비밀번호 : 알파벳, 숫자, 특수문자 포함 6자 이상이어야 합니다."),
-                fieldWithPath("url").description("이미지"),
-                fieldWithPath("profile").description("프로필")
+                fieldWithPath("url").description("프로필 이미지 URL"),
+                fieldWithPath("profile").description("자기 소개")
 
             ),
             responseFields(
                 fieldWithPath("email").description("이메일"),
                 fieldWithPath("name").description("변경된 이름"),
                 fieldWithPath("updatedAt").description("변경된 일자"),
-                fieldWithPath("url").description("이미지"),
-                fieldWithPath("profile").description("프로필")
+                fieldWithPath("url").description("프로필 이미지 URL"),
+                fieldWithPath("profile").description("자기 소개")
             )
         ));
 

--- a/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
@@ -55,7 +55,7 @@ public class PatchMember extends TestSetUpForMemberUtil {
         StubDataUtil.MockMember.getMemberPatchResponse());
 
     MemberDto.Patch patch =
-        new Patch("이슬", "modi!@#pas1", "안녕하세요. 김형섭입니다.", "https://profileImage.com");
+        new Patch("이슬", "modi!@#pas1", "안녕하세요. 이슬입니다.", "https://profileImage.com");
     String content = gson.toJson(patch);
 
     //when, then

--- a/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
@@ -73,7 +73,7 @@ public class PatchMember extends TestSetUpForMemberUtil {
                 fieldWithPath("name").description("변경할 이름"),
                 fieldWithPath("password").description("변경할 비밀번호 : 알파벳, 숫자, 특수문자 포함 6자 이상이어야 합니다."),
                 fieldWithPath("url").description("프로필 이미지 URL"),
-                fieldWithPath("profile").description("자기 소개")
+                fieldWithPath("content").description("자기 소개")
 
             ),
             responseFields(
@@ -81,7 +81,7 @@ public class PatchMember extends TestSetUpForMemberUtil {
                 fieldWithPath("name").description("변경된 이름"),
                 fieldWithPath("updatedAt").description("변경된 일자"),
                 fieldWithPath("url").description("프로필 이미지 URL"),
-                fieldWithPath("profile").description("자기 소개")
+                fieldWithPath("content").description("자기 소개")
             )
         ));
 

--- a/src/test/java/com/seollem/server/restdocs/controller/member/PostMemberImage.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/PostMemberImage.java
@@ -1,7 +1,5 @@
-package com.seollem.server.restdocs.controller.memo;
+package com.seollem.server.restdocs.controller.member;
 
-
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -14,45 +12,24 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.seollem.server.book.BookService;
-import com.seollem.server.file.FileUploadService;
-import com.seollem.server.member.MemberService;
-import com.seollem.server.memo.MemoController;
-import com.seollem.server.memo.MemoMapper;
-import com.seollem.server.memo.MemoService;
-import com.seollem.server.memolikes.MemoLikesService;
+import com.seollem.server.member.MemberController;
 import com.seollem.server.restdocs.util.StubDataUtil;
-import com.seollem.server.restdocs.util.WebMvcTestSetUpUtil;
-import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import com.seollem.server.restdocs.util.TestSetUpForMemberUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-@WebMvcTest(value = MemoController.class)
-public class PostImageMemo extends WebMvcTestSetUpUtil {
 
-  @MockBean
-  private MemoService memoService;
-  @MockBean
-  private MemoMapper memoMapper;
-  @MockBean
-  private MemberService memberService;
-  @MockBean
-  private GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
-  @MockBean
-  private BookService bookService;
-  @MockBean
-  private FileUploadService fileUploadService;
-  @MockBean
-  private MemoLikesService memoLikesService;
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@WebMvcTest(value = MemberController.class)
+public class PostMemberImage extends TestSetUpForMemberUtil {
+
 
   @Test
-  public void postImageMemoTest() throws Exception {
+  public void postMemberImageTest() throws Exception {
 
     //given
     when(getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(Mockito.anyMap())).thenReturn(
@@ -61,15 +38,16 @@ public class PostImageMemo extends WebMvcTestSetUpUtil {
     when(memberService.findVerifiedMemberByEmail(Mockito.anyString())).thenReturn(
         StubDataUtil.MockMember.getMember());
 
-    doNothing().when(bookService).verifyMemberHasBook(Mockito.anyLong(), Mockito.anyLong());
+    when(fileUploadService.createImage(Mockito.any())).thenReturn("https://imageurl.com");
 
-    when(fileUploadService.createImage(Mockito.any())).thenReturn("https://memoimageurl.com");
+    when(memberService.updateMemberImage(Mockito.any(), Mockito.any())).thenReturn(
+        StubDataUtil.MockMember.getMember());
 
     //when, then
     this.mockMvc.perform(
-            multipart("/memos/image-memo").file("file", "file".getBytes())
+            multipart("/members/member-image").file("file", "file".getBytes())
                 .header("Authorization", "Bearer JWT Access Token")).andDo(print())
-        .andExpect(status().isCreated()).andDo(document("PostImageMemo",
+        .andExpect(status().isCreated()).andDo(document("PostMemberImage",
             requestHeaders(headerWithName("Authorization").description("Bearer JWT Access Token")),
             requestParts(partWithName("file").description("업로드할 이미지 파일 : form-data")),
             responseFields(fieldWithPath("url").description("업로드된 이미지의 URL"))

--- a/src/test/java/com/seollem/server/restdocs/util/StubDataUtil.java
+++ b/src/test/java/com/seollem/server/restdocs/util/StubDataUtil.java
@@ -136,7 +136,7 @@ public class StubDataUtil {
 
     public static MemberDto.PatchResponse getMemberPatchResponse() {
       return new MemberDto.PatchResponse("starrypro@gmail.com", "이슬", LocalDateTime.now(),
-          "안녕하세요. 김형섭입니다.", "https://profileImage.com");
+          "안녕하세요. 이슬입니다.", "https://profileImage.com");
     }
   }
 

--- a/src/test/java/com/seollem/server/restdocs/util/StubDataUtil.java
+++ b/src/test/java/com/seollem/server/restdocs/util/StubDataUtil.java
@@ -124,16 +124,19 @@ public class StubDataUtil {
   public static class MockMember {
 
     public static Member getMember() {
-      return new Member(1, "starrypro@gmail.com", "김형섭", "password", "ROLE_USER",
+      return new Member(1, "starrypro@gmail.com", "김형섭", "password", "ROLE_USER", "안녕하세요. 김형섭입니다.",
+          "https://profileImage.com",
           new ArrayList<Book>(), new ArrayList<MemoLikes>());
     }
 
     public static MemberDto.GetResponse getMemberGetResponse() {
-      return new MemberDto.GetResponse("starrypro@gmail.com", "김형섭");
+      return new MemberDto.GetResponse("starrypro@gmail.com", "김형섭", "안녕하세요. 김형섭입니다.",
+          "https://profileImage.com");
     }
 
     public static MemberDto.PatchResponse getMemberPatchResponse() {
-      return new MemberDto.PatchResponse("starrypro@gmail.com", "이슬", LocalDateTime.now());
+      return new MemberDto.PatchResponse("starrypro@gmail.com", "이슬", LocalDateTime.now(),
+          "안녕하세요. 김형섭입니다.", "https://profileImage.com");
     }
   }
 

--- a/src/test/java/com/seollem/server/restdocs/util/TestSetUpForMemberUtil.java
+++ b/src/test/java/com/seollem/server/restdocs/util/TestSetUpForMemberUtil.java
@@ -1,0 +1,20 @@
+package com.seollem.server.restdocs.util;
+
+import com.seollem.server.file.FileUploadService;
+import com.seollem.server.member.MemberMapper;
+import com.seollem.server.member.MemberService;
+import com.seollem.server.util.GetEmailFromHeaderTokenUtil;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class TestSetUpForMemberUtil extends WebMvcTestSetUpUtil {
+
+  @MockBean
+  protected MemberMapper memberMapper;
+  @MockBean
+  protected MemberService memberService;
+  @MockBean
+  protected GetEmailFromHeaderTokenUtil getEmailFromHeaderTokenUtil;
+  @MockBean
+  protected FileUploadService fileUploadService;
+
+}


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #31 

## 🙌 구현 사항
- Member 엔티티에 자기소개(content), 이미지(url) 필드를 추가하고 관련 api들을 수정, 추가하였습니다.

## 📝 구현 설명
#### Member 엔티티 필드 추가에 따른 기존 api 수정 내용들
- Member 도메인에서 수정(Patch) 와 조회(Get) api 만 수정하면 되었습니다.
  1. _MemberDto.GetResponse_ 에 `content`, `url` 필드 추가
  ```java
public static class GetResponse {

    private String email;
    private String name;
    private String content;
    private String url;
  }
```
<br>

  2. _MemberDto.PatchResponse_ 에 `content`, `url` 필드 추가
  ```java
public static class PatchResponse {

    private String email;
    private String name;
    private LocalDateTime updatedAt;
    private String content;
    private String url;
  }
```
<br>

  3. MemberService.updateMember() 메소드에서 `content`, `url` 처리하는 코드 추가
  ```java
public static class PatchResponse {

    private String email;
    private String name;
    private LocalDateTime updatedAt;
    private String content;
    private String url;
  }
```
<br>

#### 회원 이미지 등록 api 추가하기
- MemberController 클래스에서 `postMemberImage()` 메소드 추가
```java
@PostMapping("/member-image")
  public ResponseEntity postMemberImage(@RequestHeader Map<String, Object> requestHeader,
      @RequestPart MultipartFile file) {
    String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
    Member member = memberService.findVerifiedMemberByEmail(email);

    String url = fileUploadService.createImage(file);
    memberService.updateMemberImage(member, url);

    MemberDto.ImageMemberResponse imageMemberResponse = new MemberDto.ImageMemberResponse(url);

    return new ResponseEntity<>(imageMemberResponse, HttpStatus.CREATED);
  }
```
- 기존의 S3 파일 업로드를 지원하는 FileUploadService 클래스를 그대로 사용하였습니다.
- 업로드 후 받은 `url` 을 `updateMemberImage()` 메소드를 통해 DB 에 저장합니다.
```java
@PostMapping("/member-image")
  public ResponseEntity postMemberImage(@RequestHeader Map<String, Object> requestHeader,
      @RequestPart MultipartFile file) {
    String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
    Member member = memberService.findVerifiedMemberByEmail(email);

    String url = fileUploadService.createImage(file);
    memberService.updateMemberImage(member, url);

    MemberDto.ImageMemberResponse imageMemberResponse = new MemberDto.ImageMemberResponse(url);

    return new ResponseEntity<>(imageMemberResponse, HttpStatus.CREATED);
  }
```
<br>

#### FileUploadService의 `createImage()` 에서 클라이언트에 예외발생을 알리기 위하여 Global Exception 으로 처리하도록 변경
```java
public String createImage(MultipartFile file) {
    String fileName = createFileName(file.getOriginalFilename());
    ObjectMetadata objectMetadata = new ObjectMetadata();
    objectMetadata.setContentLength(file.getSize());
    objectMetadata.setContentType(file.getContentType());
    try (InputStream inputStream = file.getInputStream()) {
      s3Service.uploadFile(inputStream, objectMetadata, fileName);
    } catch (IOException e) {
      log.error(String.format("파일 변환 중 에러 발생 (%s)", file.getOriginalFilename()));
      throw new BusinessLogicException(ExceptionCode.IMAGE_UPLOAD_FAIL);
    }
    return s3Service.getFileUrl(fileName);
  }
```
- try - catch 문에서 기존에는 `IllegalArgumentException` 을 발생하여 클라이언트에서 적절한 정보가 응답되지 않았습니다.
- @Slf4j 를 이용하여 로깅을 남긴 후 BusinessLogicException 을 발생시켜 정보를 알리도록 하였습니다.
- ExceptionCode 클래스에서 `IMAGE_UPLOAD_FAIL(500, "Image upload failed.");` 와 같이 추가하였습니다.

#### Spring Rest Docs 수정
- 관련 코드 수정하였습니다.

#### 개발 기록
- https://www.notion.so/my-little-seollem/API-8452a4a1163140c4a95e08e74e8d2a0b?pvs=4