### PR TITLE
Feature/#53 delete pagination book calender api

### DIFF
--- a/src/main/java/com/seollem/server/book/BookController.java
+++ b/src/main/java/com/seollem/server/book/BookController.java
@@ -86,8 +86,6 @@ public class BookController {
   @GetMapping("/calender")
   public ResponseEntity getCalender(
       @RequestHeader Map<String, Object> requestHeader,
-      @Positive @RequestParam int page,
-      @Positive @RequestParam int size,
       @Positive @RequestParam int year, @Min(1) @Max(12) @RequestParam int month) {
     String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
     Member member = memberService.findVerifiedMemberByEmail(email);
@@ -95,15 +93,11 @@ public class BookController {
     ArrayList<LocalDateTime> calenderPeriod =
         getCalenderBookUtil.getCalenderBookPeriod(year, month);
 
-    Page<Book> pageBooks =
-        bookService.findCalenderBooks(
-            page - 1, size, member, calenderPeriod.get(0), calenderPeriod.get(1),
-            Book.BookStatus.DONE, "read_end_date");
-    List<Book> books = pageBooks.getContent();
+    List<Book> books =
+        bookService.findCalenderBooks(member, calenderPeriod.get(0), calenderPeriod.get(1),
+            Book.BookStatus.DONE);
 
-    return new ResponseEntity<>(
-        new MultiResponseDto<>(bookMapper.BooksToCalenderResponse(books), pageBooks),
-        HttpStatus.OK);
+    return new ResponseEntity<>(bookMapper.BooksToCalenderResponse(books), HttpStatus.OK);
   }
 
   // 오래된 책 조회

--- a/src/main/java/com/seollem/server/book/BookRepository.java
+++ b/src/main/java/com/seollem/server/book/BookRepository.java
@@ -20,37 +20,24 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 
   //    Optional<List<Book>>  findByMember(Member member);
 
-  @Query(
-      value =
-          "SELECT * FROM book WHERE MEMBER_ID = ?1 AND BOOK_STATUS = ?2 AND READ_END_DATE > ?3 AND READ_END_DATE < ?4",
-      countQuery =
-          "SELECT count(*) FROM book WHERE MEMBER_ID = ?1 AND BOOK_STATUS = ?2 AND READ_END_DATE > ?3 AND READ_END_DATE < ?4",
-      nativeQuery = true)
-  Optional<Page<Book>> findCalender(
-      Member member, int bookStatusToInt, LocalDateTime before, LocalDateTime after,
-      Pageable pageable);
+  @Query(value = "SELECT * FROM book WHERE MEMBER_ID = ?1 AND BOOK_STATUS = ?2 AND READ_END_DATE > ?3 AND READ_END_DATE < ?4 ORDER BY READ_END_DATE", nativeQuery = true)
+  Optional<List<Book>> findCalender(Member member, int bookStatusToInt, LocalDateTime before,
+      LocalDateTime after);
 
-  Page<Book> findAllByMemberAndBookStatus(
-      Member member, Book.BookStatus bookStatus, Pageable pageable);
+  Page<Book> findAllByMemberAndBookStatus(Member member, Book.BookStatus bookStatus,
+      Pageable pageable);
 
 
   List<Book> findAllByMember(Member member);
 
   //AND CREATED_AT > ?2 AND CREATED_AT < ?3
-  @Query(
-      value =
-          "SELECT * FROM book WHERE MEMBER_ID = ?1 AND BOOK_STATUS = 0 AND NOW() >"
-              + " DATE_ADD(CREATED_AT, INTERVAL +3 MONTH)",
-      countQuery =
-          "SELECT count(*) FROM book WHERE MEMBER_ID = ?1 AND BOOK_STATUS = 0 AND NOW() >"
-              + " DATE_ADD(CREATED_AT, INTERVAL +3 MONTH)",
-      nativeQuery = true)
+  @Query(value = "SELECT * FROM book WHERE MEMBER_ID = ?1 AND BOOK_STATUS = 0 AND NOW() >"
+      + " DATE_ADD(CREATED_AT, INTERVAL +3 MONTH)", countQuery =
+      "SELECT count(*) FROM book WHERE MEMBER_ID = ?1 AND BOOK_STATUS = 0 AND NOW() >"
+          + " DATE_ADD(CREATED_AT, INTERVAL +3 MONTH)", nativeQuery = true)
   Page<Book> findAbandon(Member member, Pageable pageable);
 
-  @Query(
-      value = "SELECT * FROM book WHERE MEMBER_ID = ?1 AND MEMO_COUNT != 0",
-      countQuery = "SELECT count(*) FROM book WHERE MEMBER_ID = ?1 AND MEMO_COUNT != 0",
-      nativeQuery = true)
+  @Query(value = "SELECT * FROM book WHERE MEMBER_ID = ?1 AND MEMO_COUNT != 0", countQuery = "SELECT count(*) FROM book WHERE MEMBER_ID = ?1 AND MEMO_COUNT != 0", nativeQuery = true)
   Page<Book> findBooksHaveMemo(Member member, Pageable pageable);
 
   @Transactional

--- a/src/main/java/com/seollem/server/book/BookService.java
+++ b/src/main/java/com/seollem/server/book/BookService.java
@@ -57,30 +57,39 @@ public class BookService {
 
   public Book findVerifiedBookById(long bookId) {
     Optional<Book> optionalBookDetail = bookRepository.findById(bookId);
-    Book book =
-        optionalBookDetail.orElseThrow(
-            () -> new BusinessLogicException(ExceptionCode.BOOK_NOT_FOUND));
+    Book book = optionalBookDetail.orElseThrow(
+        () -> new BusinessLogicException(ExceptionCode.BOOK_NOT_FOUND));
 
     return book;
   }
 
-  public Page<Book> findVerifiedBooksByMemberAndBookStatus(
-      int page, int size, Member member, Book.BookStatus bookStatus, String sort) {
-    Page<Book> books =
-        bookRepository.findAllByMemberAndBookStatus(
-            member, bookStatus, PageRequest.of(page, size, Sort.by(sort).descending()));
+  public Page<Book> findVerifiedBooksByMemberAndBookStatus(int page, int size, Member member,
+      Book.BookStatus bookStatus, String sort) {
+    Page<Book> books = bookRepository.findAllByMemberAndBookStatus(member, bookStatus,
+        PageRequest.of(page, size, Sort.by(sort).descending()));
 
     return books;
   }
 
 
   public List<Book> findVerifiedBooksByMember(Member member) {
-    List<Book> books =
-        bookRepository.findAllByMember(member);
+    List<Book> books = bookRepository.findAllByMember(member);
 
     return books;
   }
 
+  public List<Book> findCalenderBooks(Member member, LocalDateTime before, LocalDateTime after,
+      Book.BookStatus bookStatus) {
+    Optional<List<Book>> optionalBooks =
+        bookRepository.findCalender(member, bookStatus.ordinal(), before, after);
+    List<Book> books = optionalBooks.orElseThrow(
+        () -> new BusinessLogicException(ExceptionCode.BOOK_NOT_FOUND_PERIOD));
+
+    return books;
+  }
+
+  // 책 Calender 조회에서 페이지네이션 기능이 제거되면서 deprecated 된 메소드
+  /*
   public Page<Book> findCalenderBooks(
       int page, int size, Member member, LocalDateTime before, LocalDateTime after,
       Book.BookStatus bookStatus, String sort) {
@@ -93,20 +102,18 @@ public class BookService {
 
     return books;
   }
+  */
 
   public Page<Book> findAbandonedBooks(int page, int size, Member member) {
-    Page<Book> books =
-        bookRepository.findAbandon(
-            member,
-            PageRequest.of(page, size, Sort.by("BOOK_ID").descending()));
+    Page<Book> books = bookRepository.findAbandon(member,
+        PageRequest.of(page, size, Sort.by("BOOK_ID").descending()));
 
     return books;
   }
 
   public Page<Book> findMemoBooks(int page, int size, Member member) {
-    Page<Book> books =
-        bookRepository.findBooksHaveMemo(
-            member, PageRequest.of(page, size, Sort.by("BOOK_ID").descending()));
+    Page<Book> books = bookRepository.findBooksHaveMemo(member,
+        PageRequest.of(page, size, Sort.by("BOOK_ID").descending()));
 
     return books;
   }

--- a/src/test/java/com/seollem/server/restdocs/controller/book/GetCalender.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/book/GetCalender.java
@@ -53,9 +53,8 @@ public class GetCalender extends TestSetUpForBookUtil {
     when(getAbandonPeriodUtil.getCalenderBookPeriod(Mockito.anyInt(), Mockito.anyInt())).thenReturn(
         tempList);
 
-    when(bookService.findCalenderBooks(Mockito.anyInt(), Mockito.anyInt(), Mockito.any(),
-        Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyString())).thenReturn(
-        StubDataUtil.MockBook.getBookPage());
+    when(bookService.findCalenderBooks(Mockito.any(), Mockito.any(), Mockito.any(),
+        Mockito.any())).thenReturn(StubDataUtil.MockBook.getBookList());
 
     given(bookMapper.BooksToCalenderResponse(Mockito.any())).willReturn(
         StubDataUtil.MockBook.getCalenderResponse());
@@ -64,25 +63,17 @@ public class GetCalender extends TestSetUpForBookUtil {
     ResultActions resultActions = mockMvc.perform(
         MockMvcRequestBuilders.get("/books/calender").accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
-            .header("Authorization", "Bearer JWT Access Token").queryParam("page", "1")
-            .queryParam("size", "2").queryParam("year", "2022").queryParam("month", "10"));
+            .header("Authorization", "Bearer JWT Access Token").queryParam("year", "2022")
+            .queryParam("month", "10"));
 
     //then
     resultActions.andExpect(status().isOk()).andDo(print()).andDo(document("Calender",
         requestHeaders(headerWithName("Authorization").description("Bearer JWT Access Token")),
-        requestParameters(parameterWithName("page").description("원하는 page"),
-            parameterWithName("size").description("페이지 별 책 개수"),
-            parameterWithName("year").description("조회할 읽기 완료 년도"),
+        requestParameters(parameterWithName("year").description("조회할 읽기 완료 년도"),
             parameterWithName("month").description("조회할 읽기 완료 월")), responseFields(
-            fieldWithPath("item[].bookId").type(JsonFieldType.NUMBER).description("책 ID"),
-            fieldWithPath("item[].readEndDate").type(JsonFieldType.STRING).description("읽기 완료한 일자"),
-            fieldWithPath("item[].cover").type(JsonFieldType.STRING).description("표지 이미지 url"),
-            fieldWithPath("pageInfo.page").type(JsonFieldType.NUMBER).description("조회 페이지"),
-            fieldWithPath("pageInfo.size").type(JsonFieldType.NUMBER).description("페이지별 책 개수"),
-            fieldWithPath("pageInfo.totalElements").type(JsonFieldType.NUMBER)
-                .description("조회된 책의 총 개수"),
-            fieldWithPath("pageInfo.totalPages").type(JsonFieldType.NUMBER)
-                .description("조회된 총 페이지 수")
+            fieldWithPath("[]bookId").type(JsonFieldType.NUMBER).description("책 ID"),
+            fieldWithPath("[]readEndDate").type(JsonFieldType.STRING).description("읽기 완료한 일자"),
+            fieldWithPath("[]cover").type(JsonFieldType.STRING).description("표지 이미지 url")
 
         )));
   }

--- a/src/test/java/com/seollem/server/restdocs/controller/member/GetMember.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/GetMember.java
@@ -49,8 +49,8 @@ public class GetMember extends TestSetUpForMemberUtil {
         responseFields(
             fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
             fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
-            fieldWithPath("url").type(JsonFieldType.STRING).description("이미지"),
-            fieldWithPath("profile").type(JsonFieldType.STRING).description("프로필")
+            fieldWithPath("content").type(JsonFieldType.STRING).description("자기 소개"),
+            fieldWithPath("url").type(JsonFieldType.STRING).description("이미지")
 
         )));
   }

--- a/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/member/PatchMember.java
@@ -72,16 +72,16 @@ public class PatchMember extends TestSetUpForMemberUtil {
             requestFields(
                 fieldWithPath("name").description("변경할 이름"),
                 fieldWithPath("password").description("변경할 비밀번호 : 알파벳, 숫자, 특수문자 포함 6자 이상이어야 합니다."),
-                fieldWithPath("url").description("프로필 이미지 URL"),
-                fieldWithPath("content").description("자기 소개")
+                fieldWithPath("content").description("자기 소개"),
+                fieldWithPath("url").description("프로필 이미지 URL")
 
             ),
             responseFields(
                 fieldWithPath("email").description("이메일"),
                 fieldWithPath("name").description("변경된 이름"),
                 fieldWithPath("updatedAt").description("변경된 일자"),
-                fieldWithPath("url").description("프로필 이미지 URL"),
-                fieldWithPath("content").description("자기 소개")
+                fieldWithPath("content").description("자기 소개"),
+                fieldWithPath("url").description("프로필 이미지 URL")
             )
         ));
 

--- a/src/test/java/com/seollem/server/restdocs/util/StubDataUtil.java
+++ b/src/test/java/com/seollem/server/restdocs/util/StubDataUtil.java
@@ -34,6 +34,25 @@ public class StubDataUtil {
           LocalDateTime.parse("2022-10-13T21:04:32"), new Member(), null);
     }
 
+    public static List<Book> getBookList() {
+
+      List<Book> books = new ArrayList<>();
+
+      Book book1 =
+          new com.seollem.server.book.Book(1, "미움받을용기", "https://imageurl1.com", "아들러", "한빛출판사",
+              214, 406, 5, BookStatus.DONE, LocalDateTime.parse("2022-10-02T11:09:10"),
+              LocalDateTime.parse("2022-10-13T21:04:32"), new Member(), null);
+      Book book2 =
+          new com.seollem.server.book.Book(12, "차라투스트라는 이렇게 말했다.", "https://imageurl12.com", "니체",
+              "원호출판사", 15, 898, 0, BookStatus.DONE, LocalDateTime.parse("2022-09-03T10:15:30"),
+              LocalDateTime.parse("2022-10-04T12:15:33"), new Member(), null);
+
+      books.add(book1);
+      books.add(book2);
+
+      return books;
+    }
+
 
     public static PageImpl<Book> getBookPage() {
       List<Book> list = new ArrayList<>();


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #53 

## 🙌 구현 사항
- 책 Calender 조회 는 조회할 년도/월 에 따라 조회되므로 데이터 수의 제한이 이뤄지고, 프론트에서 페이지 수의 값을 정하기 어려웠으므로 페이지네이션을 제거합니다.

## 📝 구현 설명
- 개발 노트로 대체합니다.
https://www.notion.so/my-little-seollem/Calender-API-446d4fc8516d4f8aa5174a59581800de?pvs=4
