### PR TITLE
:bug: 다른회원 프로필 조회 로직 오류 해결

### DIFF
--- a/src/main/java/com/seollem/server/member/MemberController.java
+++ b/src/main/java/com/seollem/server/member/MemberController.java
@@ -96,8 +96,10 @@ public class MemberController {
     String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
     Member member = memberService.findVerifiedMemberByEmail(email);
 
+    Member findMember = memberService.findVerifiedMemberById(memberId);
+
     OtherMemberProfileResponseDto result =
-        memberService.getOtherMemberProfile(page - 1, size, member);
+        memberService.getOtherMemberProfile(page - 1, size, findMember);
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/src/main/java/com/seollem/server/member/MemberService.java
+++ b/src/main/java/com/seollem/server/member/MemberService.java
@@ -61,6 +61,13 @@ public class MemberService {
     }
   }
 
+  public Member findVerifiedMemberById(long memberId) {
+    Optional<Member> optionalMember = memberRepository.findById(memberId);
+    Member member = optionalMember.orElseThrow(
+        () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+    return member;
+  }
+
   public Member findVerifiedMemberByEmail(String email) {
     Optional<Member> optionalMember = memberRepository.findByEmail(email);
     Member member = optionalMember.orElseThrow(


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed 

## 🙌 구현 사항
- `다른회원 프로필조회` 비즈니스 로직 오류를 수정합니다.

## 📝 구현 설명
- 기존 코드
```java
@GetMapping(path = "/other/{member-id}")
  public ResponseEntity getOtherMemberProfile(@RequestHeader Map<String, Object> requestHeader,
      @Positive @PathVariable("member-id") long memberId, @Positive @RequestParam int page,
      @Positive @RequestParam int size) {
    String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
    Member member = memberService.findVerifiedMemberByEmail(email);

    OtherMemberProfileResponseDto result =
        memberService.getOtherMemberProfile(page - 1, size, member);

    return new ResponseEntity<>(result, HttpStatus.OK);
  }
```
기존 코드에서는 요청한 회원의 Member 객체를 이용해 조회하는 오류가 있었습니다. 요청한 회원이 아닌 PathVariable 로 들어온 `memberId` 로 조회하도록 변경해야합니다.

<br>

- 변경된 코드
```java
@GetMapping(path = "/other/{member-id}")
  public ResponseEntity getOtherMemberProfile(@RequestHeader Map<String, Object> requestHeader,
      @Positive @PathVariable("member-id") long memberId, @Positive @RequestParam int page,
      @Positive @RequestParam int size) {
    String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
    Member member = memberService.findVerifiedMemberByEmail(email);

    Member findMember = memberService.findVerifiedMemberById(memberId); // 이부분!

    OtherMemberProfileResponseDto result =
        memberService.getOtherMemberProfile(page - 1, size, findMember);

    return new ResponseEntity<>(result, HttpStatus.OK);
  }
```
memberId 를 이용해 조회하는 `MemberService.findVerifiedMemberById()` 메소드를 이용하도록 변경하였습니다.
