### PR TITLE
Hotfix/#65 fix cancel memo like logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.seollem'
-version = '2.2.2-SNAPSHOT'
+version = '2.2.3-SNAPSHOT'
 sourceCompatibility = '11'
 
 repositories {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -400,9 +400,6 @@ include::{snippets}/PostMemoLike/path-parameters.adoc[]
 .response
 include::{snippets}/PostMemoLike/http-response.adoc[]
 
-.response fields
-include::{snippets}/PostMemoLike/response-fields.adoc[]
-
 === 메모 좋아요 삭제
 .request
 include::{snippets}/DeleteMemoLike/http-request.adoc[]

--- a/src/main/java/com/seollem/server/book/BookService.java
+++ b/src/main/java/com/seollem/server/book/BookService.java
@@ -11,8 +11,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class BookService {
 
   private final BookRepository bookRepository;

--- a/src/main/java/com/seollem/server/member/MemberService.java
+++ b/src/main/java/com/seollem/server/member/MemberService.java
@@ -14,9 +14,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
 
   private final MemberRepository memberRepository;

--- a/src/main/java/com/seollem/server/memo/MemoService.java
+++ b/src/main/java/com/seollem/server/memo/MemoService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemoService {
 
   public final MemoRepository memoRepository;

--- a/src/main/java/com/seollem/server/memolike/MemoLikeController.java
+++ b/src/main/java/com/seollem/server/memolike/MemoLikeController.java
@@ -45,17 +45,18 @@ public class MemoLikeController {
     return new ResponseEntity(HttpStatus.CREATED);
   }
 
-  @DeleteMapping(path = "/{memo-like-id}")
+  @DeleteMapping(path = "/{memo-id}")
   public ResponseEntity cancelLike(
       @RequestHeader Map<String, Object> requestHeader,
-      @Positive @PathVariable("memo-like-id") long memoLikeId) {
+      @Positive @PathVariable("memo-id") long memoId) {
 
     String email = getEmailFromHeaderTokenUtil.getEmailFromHeaderToken(requestHeader);
     Member member = memberService.findVerifiedMemberByEmail(email);
+    Memo memo = memoService.findVerifiedMemo(memoId);
 
-    MemoLike memoLike = memoLikeService.findVerifiedMemoLikeById(memoLikeId);
+    MemoLike memoLike = memoLikeService.findVerifiedMemoLikeByMemoAndMember(memo, member);
     memoLikeService.verifyMemberHasMemoLike(member, memoLike);
-    memoLikeService.deleteMemoLikeWithMemoLike(memoLike);
+    memoLikeService.deleteMemoLike(memoLike);
 
     return new ResponseEntity(HttpStatus.NO_CONTENT);
   }

--- a/src/main/java/com/seollem/server/memolike/MemoLikeController.java
+++ b/src/main/java/com/seollem/server/memolike/MemoLikeController.java
@@ -40,11 +40,9 @@ public class MemoLikeController {
 
     Memo memo = memoService.findVerifiedMemo(memoId);
 
-    MemoLike savedMemoLike = memoLikeService.createMemoLike(memo, member);
+    memoLikeService.createMemoLike(memo, member);
 
-    MemoLikeResponseDto responseDto = new MemoLikeResponseDto(savedMemoLike.getMemoLikeId());
-
-    return new ResponseEntity(responseDto, HttpStatus.CREATED);
+    return new ResponseEntity(HttpStatus.CREATED);
   }
 
   @DeleteMapping(path = "/{memo-like-id}")

--- a/src/main/java/com/seollem/server/memolike/MemoLikeService.java
+++ b/src/main/java/com/seollem/server/memolike/MemoLikeService.java
@@ -27,6 +27,16 @@ public class MemoLikeService {
     return memoLike;
   }
 
+  public MemoLike findVerifiedMemoLikeByMemoAndMember(Memo memo, Member member) {
+    List<MemoLike> memoLikes = memoLikeRepository.findAllByMemoAndMember(memo, member);
+    if (!memoLikes.isEmpty()) {
+      return memoLikes.get(0);
+    } else {
+      throw new BusinessLogicException(ExceptionCode.MEMOLIKE_NOT_FOUND);
+    }
+  }
+
+
   public void verifyMemberHasMemoLike(Member member, MemoLike memoLike) {
     if (!(memoLike.getMember() == member)) {
       throw new BusinessLogicException(ExceptionCode.NOT_MEMBER_MEMOLIKE);
@@ -62,7 +72,7 @@ public class MemoLikeService {
     }
   }
 
-  public void deleteMemoLikeWithMemoLike(MemoLike memoLike) {
+  public void deleteMemoLike(MemoLike memoLike) {
     memoLikeRepository.delete(memoLike);
   }
 

--- a/src/main/java/com/seollem/server/memolike/MemoLikeService.java
+++ b/src/main/java/com/seollem/server/memolike/MemoLikeService.java
@@ -51,15 +51,14 @@ public class MemoLikeService {
     return result;
   }
 
-  public MemoLike createMemoLike(Memo memo, Member member) {
+  public void createMemoLike(Memo memo, Member member) {
     // 해당 메모의 메모좋아요 객체 중에서 이미 해당 회원의 객체가 있는 지 확인합니다.
     List<MemoLike> memoLikes = memoLikeRepository.findAllByMemoAndMember(memo, member);
     if (!memoLikes.isEmpty()) {
       throw new BusinessLogicException(ExceptionCode.MEMOLIKE_ALREADY_DONE);
     } else {
       MemoLike memoLike = memoLikeMapper.toMemoLike(memo, member);
-      MemoLike savedMemoLike = memoLikeRepository.save(memoLike);
-      return savedMemoLike;
+      memoLikeRepository.save(memoLike);
     }
   }
 

--- a/src/main/java/com/seollem/server/memolike/MemoLikeService.java
+++ b/src/main/java/com/seollem/server/memolike/MemoLikeService.java
@@ -9,9 +9,11 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class MemoLikeService {
 
   private final MemoLikeRepository memoLikeRepository;

--- a/src/main/java/com/seollem/server/temppassword/TempPasswordService.java
+++ b/src/main/java/com/seollem/server/temppassword/TempPasswordService.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class TempPasswordService {
 
   private final JavaMailSenderImpl sender;

--- a/src/test/java/com/seollem/server/restdocs/controller/memolike/DeleteMemoLike.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/memolike/DeleteMemoLike.java
@@ -38,19 +38,24 @@ public class DeleteMemoLike extends TestSetUpForMemoLikeUtil {
     when(memberService.findVerifiedMemberByEmail(Mockito.anyString())).thenReturn(
         StubDataUtil.MockMember.getMember());
 
-    when(memoLikeService.findVerifiedMemoLikeById(Mockito.anyLong())).thenReturn(new MemoLike());
+    when(memoService.findVerifiedMemo(Mockito.anyLong())).thenReturn(
+        StubDataUtil.MockMemo.getMemos()
+            .get(0));
+
+    when(memoLikeService.findVerifiedMemoLikeByMemoAndMember(Mockito.any(),
+        Mockito.any())).thenReturn(new MemoLike());
 
     doNothing().when(memoLikeService).verifyMemberHasMemoLike(Mockito.any(), Mockito.any());
-    doNothing().when(memoLikeService).deleteMemoLikeWithMemoLike(Mockito.any(MemoLike.class));
+    doNothing().when(memoLikeService).deleteMemoLike(Mockito.any(MemoLike.class));
 
     //when, then
     this.mockMvc.perform(
-            delete("/memo-like/{memo-like-id}", 1).contentType(MediaType.APPLICATION_JSON)
+            delete("/memo-like/{memo-id}", 1).contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding(Charset.defaultCharset())
                 .header("Authorization", "Bearer JWT Access Token")).andDo(print())
         .andExpect(status().isNoContent()).andDo(document("DeleteMemoLike",
             requestHeaders(headerWithName("Authorization").description("Bearer JWT Access Token")),
-            pathParameters(parameterWithName("memo-like-id").description("메모좋아요 ID"))));
+            pathParameters(parameterWithName("memo-id").description("삭제할 메모 ID"))));
 
   }
 

--- a/src/test/java/com/seollem/server/restdocs/controller/memolike/PostMemoLike.java
+++ b/src/test/java/com/seollem/server/restdocs/controller/memolike/PostMemoLike.java
@@ -1,12 +1,11 @@
 package com.seollem.server.restdocs.controller.memolike;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -42,8 +41,7 @@ public class PostMemoLike extends TestSetUpForMemoLikeUtil {
 
     when(memoService.findVerifiedMemo(Mockito.anyLong())).thenReturn(new Memo());
 
-    when(memoLikeService.createMemoLike(Mockito.any(), Mockito.any())).thenReturn(
-        StubDataUtil.MockMemoLike.getMemoLike());
+    doNothing().when(memoLikeService).createMemoLike(Mockito.any(), Mockito.any());
 
     //when, then
     this.mockMvc.perform(
@@ -52,8 +50,7 @@ public class PostMemoLike extends TestSetUpForMemoLikeUtil {
                 .header("Authorization", "Bearer JWT Access Token")).andDo(print())
         .andExpect(status().isCreated()).andDo(document("PostMemoLike",
             requestHeaders(headerWithName("Authorization").description("Bearer JWT Access Token")),
-            pathParameters(parameterWithName("memo-id").description("메모 좋아요를 등록할 메모 ID")),
-            responseFields(fieldWithPath("memoLikeId").description("등록된 메모 좋아요 ID"))));
+            pathParameters(parameterWithName("memo-id").description("메모 좋아요를 등록할 메모 ID"))));
 
   }
 


### PR DESCRIPTION
## 🔗 ISSUE NUMBER
<!-- closed #[issue-number]로 작성하면 이슈가 닫히고, 링크도 연결할 수 있어요 -->

- closed #65 

## 🙌 구현 사항
- 메모 좋아요 취소(삭제) 기능의 로직을 일부 변경합니다. 

## 📝 구현 설명
- 기존 `메모 좋아요 취소` 기능의 설계가 잘못 되었습니다. 기존에는 `memo-like-id` 를 통해 취소를 하게 됩니다. 해당 기능을 _**다른 회원 메모 조회**_ 페이지에서 사용하게 되는데, 해당 페이지에서는 `memo-like-id` 를 알 수 없습니다. 따라서 `memo-id` 를 통해 취소요청을 할 수 있도록 변경합니다.
- `memo-id` 를 통해 해당 메모에 달린 `MemoLike` 객체들 중에서 JWT 에서 가져온 `Member` 정보와 일치하는 객체를 찾게 되면, 한명의 `Member` 는 해당 메모에서 단 하나의 `MemoLike` 객체만 가지고 있으므로 정확한 타겟을 찾을 수 있습니다.
- 코드의 변경은 많지 않아 설명하지 않으니 확인바랍니다.
